### PR TITLE
DVOP-2126 migrate from centos8 to amazonlinux2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 FROM amazonlinux:2
 
-ARG ruby_version=2.7.1
+ARG ruby_major_version=2
+ARG ruby_minor_version=7
+ARG ruby_patch_version=1
+ARG ruby_version=${ruby_major_version}.${ruby_minor_version}.${ruby_patch_version}
 
 RUN yum update -y && \
     yum install -y \
@@ -11,13 +14,16 @@ RUN yum update -y && \
     gcc-c++ \
     openssl-devel \
     wget \
-    unzip
+    unzip && \
+    yum clean all
 
-RUN wget https://cache.ruby-lang.org/pub/ruby/2.7/ruby-${ruby_version}.zip
-RUN unzip ruby-${ruby_version}.zip
-RUN ./ruby-${ruby_version}/configure
+RUN mkdir /tmp/ruby-source
+RUN wget https://cache.ruby-lang.org/pub/ruby/${ruby_major_version}.${ruby_minor_version}/ruby-${ruby_version}.zip -P /tmp/ruby-source
+RUN unzip /tmp/ruby-source/ruby-${ruby_version}.zip -d /tmp/ruby-source
+RUN ./tmp/ruby-source/ruby-${ruby_version}/configure
 RUN make
 RUN make install
+RUN rm /tmp/ruby-source -fr
 
 RUN /bin/bash -l -c "gem install bundler"
 RUN /bin/bash -l -c "gem install middleman"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8.1.1911
+FROM amazonlinux:2
 
 ARG ruby_version=2.7.1
 
@@ -9,16 +9,15 @@ RUN yum update -y && \
     bzip2 \
     epel-release \
     gcc-c++ \
-    openssl-devel
+    openssl-devel \
+    wget \
+    unzip
 
-RUN git clone https://github.com/rbenv/rbenv.git ~/.rbenv
-RUN echo 'export PATH="$HOME/.rbenv/bin:$PATH"' >> ~/.bashrc
-RUN echo 'eval "$(rbenv init -)"' >> ~/.bashrc
+RUN wget https://cache.ruby-lang.org/pub/ruby/2.7/ruby-${ruby_version}.zip
+RUN unzip ruby-${ruby_version}.zip
+RUN ./ruby-${ruby_version}/configure
+RUN make
+RUN make install
 
-RUN git clone https://github.com/rbenv/ruby-build.git ~/.rbenv/plugins/ruby-build
-RUN echo 'export PATH="$HOME/.rbenv/plugins/ruby-build/bin:$PATH"' >> ~/.bashrc
-
-RUN /bin/bash -l -c "rbenv install ${ruby_version}"
-RUN /bin/bash -l -c "rbenv global ${ruby_version}"
 RUN /bin/bash -l -c "gem install bundler"
 RUN /bin/bash -l -c "gem install middleman"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,5 @@ A Docker configuration for Ruby-based CI builds
 The following list details the build tools required by all CHS Ruby-based services which will be installed in the container image:
 
 * Ruby
-* Rbenv - ruby version management tool
 * Bundler - provides a consistent environment for Ruby projects by tracking and installing the exact gems and versions that are needed
 * Middleman - static site generator using all the shortcuts and tools in modern web development


### PR DESCRIPTION
centos has been deprecated. move to amazonlinux2.
remove extraneous software to ensure that image is kept small and fast-booting.